### PR TITLE
Put URL into double quotes

### DIFF
--- a/dyndns-update.sh
+++ b/dyndns-update.sh
@@ -32,10 +32,10 @@ host_ipv6=$(dig @$test_dns_server +short -t aaaa $hostname | head -n 1)
 # Update DynDNS IP if not correct
 if [ $enable_ipv6 = true -a -n "$ipv6" ]; then
   if [ "$host_ipv4" != "$ipv4" -o "$host_ipv6" != "$ipv6" ]; then
-    curl --user $username:$password ${dyndns_update_url}myip=${ipv4}&myipv6=${ipv6}
+    curl --user $username:$password "${dyndns_update_url}myip=${ipv4}&myipv6=${ipv6}"
   fi
 else
   if [ "$host_ipv4" != "$ipv4" ]; then
-    curl --user $username:$password ${dyndns_update_url}myip=${ipv4}
+    curl --user $username:$password "${dyndns_update_url}myip=${ipv4}"
   fi
 fi


### PR DESCRIPTION
The ampersand in URL is interpreted by bash to run the curl command in background. So there is never an update for ipv6 addresses.